### PR TITLE
Fix Null Pointer Issues

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<classpath>
+	<classpathentry kind="src" path="presentation/src/main/java/"/>
+	<classpathentry kind="src" path="android-smsmms/src/main/java/"/>
+	<classpathentry kind="src" path="common/src/main/java/"/>
+	<classpathentry kind="lib" path="/workspace/source/gradle/wrapper/gradle-wrapper.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+</classpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>source</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/android-smsmms/src/main/java/com/android/mms/dom/NodeListImpl.java
+++ b/android-smsmms/src/main/java/com/android/mms/dom/NodeListImpl.java
@@ -74,7 +74,19 @@ public class NodeListImpl implements NodeList {
         if (mStaticNodes == null) {
             fillList(mRootNode);
             try {
-                node = mSearchNodes.get(index);
+                
+				/* ******** Warning********
+				 Possible null pointer dereference!
+				 Path: 
+					File: SmilLayoutElementImpl.java, Line: 49
+						childNodes.item(i)
+						 Information about field mSearchNodes (from class NodeListImpl) is passed through the method call. This later results into a null pointer dereference
+						The expression is enclosed inside an If statement.
+					File: NodeListImpl.java, Line: 77
+						node=mSearchNodes.get(index);
+						mSearchNodes is referenced in method invocation.
+				*/
+				node = mSearchNodes.get(index);
             } catch (IndexOutOfBoundsException e) {
                 // Do nothing and return null
             }


### PR DESCRIPTION
In file: NodeListImpl.java, class: NodeListImpl, there is a method item that there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. I detected the null pointer issue and demonstrated the full path from the object declaration to the null dereference in the object. A developer should introduce null checks in the appropriate path or initialize the object explicitly. 