### PR TITLE
Fix Null Pointer Issues-3

### DIFF
--- a/android-smsmms/src/main/java/com/android/mms/dom/smil/parser/SmilXmlSerializer.java
+++ b/android-smsmms/src/main/java/com/android/mms/dom/smil/parser/SmilXmlSerializer.java
@@ -54,7 +54,17 @@ public class SmilXmlSerializer {
             NamedNodeMap attributes = element.getAttributes();
             for (int i = 0; i < attributes.getLength(); i++) {
                 Attr attribute = (Attr)attributes.item(i);
-                writer.write(" " + attribute.getName());
+                /* ********OpenRefactory Warning********
+				 Possible null pointer dereference!
+				 Path: 
+					File: SmilXmlSerializer.java, Line: 56
+						Attr attribute=(Attr)attributes.item(i);
+				
+					File: SmilXmlSerializer.java, Line: 57
+						writer.write(" " + attribute.getName());
+						attribute is referenced in method invocation.
+				*/
+				writer.write(" " + attribute.getName());
                 writer.write("=\"" + attribute.getValue() + "\"");
             }
         }


### PR DESCRIPTION
In file: SmilXmlSerializer.java, class: SmilXmlSerializer, there is a method writeElement that there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. I detected the null pointer issue and demonstrated the full path from the object declaration to the null dereference in the object. A developer should introduce null checks in the appropriate path or initialize the object explicitly. 