### PR TITLE
Fix Null Pointer Issues-11

### DIFF
--- a/android-smsmms/src/main/java/com/android/mms/util/DownloadManager.java
+++ b/android-smsmms/src/main/java/com/android/mms/util/DownloadManager.java
@@ -130,7 +130,18 @@ public class DownloadManager {
         try {
             NotificationInd nInd = (NotificationInd) PduPersister.getPduPersister(mContext)
                     .load(uri);
-            if ((nInd.getExpiry() < System.currentTimeMillis() / 1000L)
+            /* ******** Warning********
+			 Possible null pointer dereference!
+			 Path: 
+				File: DownloadManager.java, Line: 131
+					NotificationInd nInd=(NotificationInd)PduPersister.getPduPersister(mContext).load(uri);
+			
+				File: DownloadManager.java, Line: 133
+					nInd.getExpiry()
+					nInd is referenced in method invocation.
+					The expression is enclosed inside an If statement.
+			*/
+			if ((nInd.getExpiry() < System.currentTimeMillis() / 1000L)
                     && (state == STATE_DOWNLOADING || state == STATE_PRE_DOWNLOADING)) {
                 mHandler.post(new Runnable() {
                     public void run() {


### PR DESCRIPTION
In file: DownloadManager.java, class: DownloadManager, there is a method markState that there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. I detected the null pointer issue and demonstrated the full path from the object declaration to the null dereference in the object. A developer should introduce null checks in the appropriate path or initialize the object explicitly. 