### PR TITLE
Fix Null Pointer Issues-8

### DIFF
--- a/android-smsmms/src/main/java/com/android/mms/transaction/TransactionService.java
+++ b/android-smsmms/src/main/java/com/android/mms/transaction/TransactionService.java
@@ -813,7 +813,19 @@ public class TransactionService extends Service implements Observer {
             synchronized (mProcessing) {
                 for (Transaction t : mPending) {
                     if (t.isEquivalent(transaction)) {
-                        Timber.v("Transaction already pending: " + transaction.getServiceId());
+                        
+						/* ******** Warning********
+						 Possible null pointer dereference!
+						 Path: 
+							File: TransactionService.java, Line: 697
+								processTransaction(transaction)
+								 Information is passed through the method call via transaction to the formal param transaction of the method. This later results into a null pointer dereference.
+								The expression is enclosed inside an If statement.
+							File: TransactionService.java, Line: 816
+								Timber.v("Transaction already pending: " + transaction.getServiceId());
+								transaction is referenced in method invocation.
+						*/
+						Timber.v("Transaction already pending: " + transaction.getServiceId());
                         return true;
                     }
                 }


### PR DESCRIPTION
In file: TransactionService.java, class: ServiceHandler, there is a method processTransaction that there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. I detected the null pointer issue and demonstrated the full path from the object declaration to the null dereference in the object. A developer should introduce null checks in the appropriate path or initialize the object explicitly. 