### PR TITLE
Fix Null Pointer Issues-16

### DIFF
--- a/android-smsmms/src/main/java/com/google/android/mms/pdu_alt/PduComposer.java
+++ b/android-smsmms/src/main/java/com/google/android/mms/pdu_alt/PduComposer.java
@@ -482,7 +482,25 @@ public class PduComposer {
             case PduHeaders.MMS_VERSION:
                 appendOctet(field);
 
-                int version = mPduHeader.getOctet(field);
+			/* ******** Warning********
+			 Possible null pointer dereference!
+			 Path: 
+				File: ReadRecTransaction.java, Line: 83
+					byte[] postingData=new PduComposer(mContext,readRecInd).make();
+					 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+				File: PduComposer.java, Line: 167
+					makeAckInd()
+					 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+					The expression is enclosed inside an If statement.
+				File: PduComposer.java, Line: 746
+					appendHeader(PduHeaders.MMS_VERSION)
+					 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+					The expression is enclosed inside an If statement.
+				File: PduComposer.java, Line: 485
+					int version=mPduHeader.getOctet(field);
+					mPduHeader is referenced in method invocation.
+			*/
+			int version = mPduHeader.getOctet(field);
                 if (0 == version) {
                     appendShortInteger(PduHeaders.CURRENT_MMS_VERSION);
                 } else {


### PR DESCRIPTION
In file: PduComposer.java, class: PduComposer, there is a method appendHeader that there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. iCR detected the null pointer issue and demonstrated the full path from the object declaration to the null dereference in the object. A developer should introduce null checks in the appropriate path or initialize the object explicitly. 