### PR TITLE
Fix Null Pointer Issues-17

### DIFF
--- a/android-smsmms/src/main/java/com/google/android/mms/pdu_alt/PduComposer.java
+++ b/android-smsmms/src/main/java/com/google/android/mms/pdu_alt/PduComposer.java
@@ -563,7 +563,25 @@ public class PduComposer {
             case PduHeaders.PRIORITY:
             case PduHeaders.DELIVERY_REPORT:
             case PduHeaders.READ_REPORT:
-                int octet = mPduHeader.getOctet(field);
+			/* ********OpenRefactory Warning********
+			 Possible null pointer dereference!
+			 Path: 
+				File: ReadRecTransaction.java, Line: 83
+					byte[] postingData=new PduComposer(mContext,readRecInd).make();
+					 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+				File: PduComposer.java, Line: 172
+					makeReadRecInd()
+					 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+					The expression is enclosed inside an If statement.
+				File: PduComposer.java, Line: 661
+					appendHeader(PduHeaders.MMS_VERSION)
+					 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+					The expression is enclosed inside an If statement.
+				File: PduComposer.java, Line: 566
+					int octet=mPduHeader.getOctet(field);
+					mPduHeader is referenced in method invocation.
+			*/
+			int octet = mPduHeader.getOctet(field);
                 if (0 == octet) {
                     return PDU_COMPOSE_FIELD_NOT_SET;
                 }


### PR DESCRIPTION
In file: PduComposer.java, class: PduComposer, there is a method appendHeader that there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. iCR detected the null pointer issue and demonstrated the full path from the object declaration to the null dereference in the object. A developer should introduce null checks in the appropriate path or initialize the object explicitly. 