### PR TITLE
Fix Null Pointer Issues-18

### DIFF
--- a/android-smsmms/src/main/java/com/google/android/mms/pdu_alt/PduComposer.java
+++ b/android-smsmms/src/main/java/com/google/android/mms/pdu_alt/PduComposer.java
@@ -769,7 +769,21 @@ public class PduComposer {
         // X-Mms-Transaction-ID
         appendOctet(PduHeaders.TRANSACTION_ID);
 
-        byte[] trid = mPduHeader.getTextString(PduHeaders.TRANSACTION_ID);
+        /* ********OpenRefactory Warning********
+		 Possible null pointer dereference!
+		 Path: 
+			File: ReadRecTransaction.java, Line: 83
+				byte[] postingData=new PduComposer(mContext,readRecInd).make();
+				 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+			File: PduComposer.java, Line: 157
+				makeSendReqPdu()
+				 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+				The expression is enclosed inside an If statement.
+			File: PduComposer.java, Line: 772
+				byte[] trid=mPduHeader.getTextString(PduHeaders.TRANSACTION_ID);
+				mPduHeader is referenced in method invocation.
+		*/
+		byte[] trid = mPduHeader.getTextString(PduHeaders.TRANSACTION_ID);
         if (trid == null) {
             // Transaction-ID should be set(by Transaction) before make().
             throw new IllegalArgumentException("Transaction-ID is null.");


### PR DESCRIPTION
In file: PduComposer.java, class: PduComposer, there is a method makeSendReqPdu that there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. iCR detected the null pointer issue and demonstrated the full path from the object declaration to the null dereference in the object. A developer should introduce null checks in the appropriate path or initialize the object explicitly. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF)(https://openssf.org/): Project Alpha-Omega(https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.