### PR TITLE
[ TEST PR ]

### DIFF
--- a/android-smsmms/src/main/java/com/google/android/mms/pdu_alt/PduComposer.java
+++ b/android-smsmms/src/main/java/com/google/android/mms/pdu_alt/PduComposer.java
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+//  Adding my comment
+//  @ataf
+
 package com.google.android.mms.pdu_alt;
 
 import android.content.ContentResolver;
@@ -573,7 +576,25 @@ public class PduComposer {
                 break;
 
             case PduHeaders.DATE:
-                long date = mPduHeader.getLongInteger(field);
+			/* ********OpenRefactory Warning********
+			 Possible null pointer dereference!
+			 Path: 
+				File: ReadRecTransaction.java, Line: 83
+					byte[] postingData=new PduComposer(mContext,readRecInd).make();
+					 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+				File: PduComposer.java, Line: 172
+					makeReadRecInd()
+					 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+					The expression is enclosed inside an If statement.
+				File: PduComposer.java, Line: 666
+					appendHeader(PduHeaders.MESSAGE_ID)
+					 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+					The expression is enclosed inside an If statement.
+				File: PduComposer.java, Line: 576
+					long date=mPduHeader.getLongInteger(field);
+					mPduHeader is referenced in method invocation.
+			*/
+			long date = mPduHeader.getLongInteger(field);
                 if (-1 == date) {
                     return PDU_COMPOSE_FIELD_NOT_SET;
                 }
@@ -618,7 +639,25 @@ public class PduComposer {
                 break;
 
             case PduHeaders.EXPIRY:
-                long expiry = mPduHeader.getLongInteger(field);
+			/* ********OpenRefactory Warning********
+			 Possible null pointer dereference!
+			 Path: 
+				File: ReadRecTransaction.java, Line: 83
+					byte[] postingData=new PduComposer(mContext,readRecInd).make();
+					 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+				File: PduComposer.java, Line: 172
+					makeReadRecInd()
+					 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+					The expression is enclosed inside an If statement.
+				File: PduComposer.java, Line: 671
+					appendHeader(PduHeaders.TO)
+					 Information about field mPduHeader (from class PduComposer) is passed through the method call. This later results into a null pointer dereference
+					The expression is enclosed inside an If statement.
+				File: PduComposer.java, Line: 621
+					long expiry=mPduHeader.getLongInteger(field);
+					mPduHeader is referenced in method invocation.
+			*/
+			long expiry = mPduHeader.getLongInteger(field);
                 if (-1 == expiry) {
                     return PDU_COMPOSE_FIELD_NOT_SET;
                 }


### PR DESCRIPTION
In file: PduComposer.java, class: PduComposer, there is a method appendHeader that there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. iCR detected the null pointer issue and demonstrated the full path from the object declaration to the null dereference in the object. A developer should introduce null checks in the appropriate path or initialize the object explicitly. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF)(https://openssf.org/): Project Alpha-Omega(https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.